### PR TITLE
Improved performances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,22 +2,59 @@ let props = ["width", "height", "top", "right", "bottom", "left"];
 
 let rectChanged = (a = {}, b = {}) => props.some(prop => a[prop] !== b[prop]);
 
-export default (node, cb) => {
-  let rect;
-  let rafId;
+let observedNodes = new Map();
+let rafId;
 
-  let observe = () => {
-    let newRect = node.getBoundingClientRect();
-    if (rectChanged(newRect, rect)) {
-      rect = newRect;
-      cb(rect);
+let run = () => {
+  observedNodes.forEach(state => {
+    if (state.hasRectChanged) {
+      state.callbacks.forEach(cb => cb(state.rect));
+      state.hasRectChanged = false;
     }
-    rafId = requestAnimationFrame(observe);
-  };
+  });
 
-  let unobserve = () => {
-    cancelAnimationFrame(rafId);
-  };
+  setTimeout(() => {
+    observedNodes.forEach((state, node) => {
+      let newRect = node.getBoundingClientRect();
+      if (rectChanged(newRect, state.rect)) {
+        state.hasRectChanged = true;
+        state.rect = newRect;
+      }
+    });
+  }, 0);
 
-  return { observe, unobserve };
+  rafId = requestAnimationFrame(run);
+};
+
+export default (node, cb) => {
+  return {
+    observe() {
+      let wasEmpty = observedNodes.size === 0;
+      if (observedNodes.has(node)) {
+        observedNodes.get(node).callbacks.push(cb);
+      } else {
+        observedNodes.set(node, {
+          rect: undefined,
+          hasRectChanged: false,
+          callbacks: [cb]
+        });
+      }
+      if (wasEmpty) run();
+    },
+
+    unobserve() {
+      let state = observedNodes.get(node);
+      if (state) {
+        // Remove the callback
+        const index = state.callbacks.indexOf(cb);
+        if (index >= 0) state.callbacks.splice(index, 1);
+
+        // Remove the node reference
+        if (!state.callbacks.length) observedNodes.delete(node);
+
+        // Stop the loop
+        if (!observedNodes.size) cancelAnimationFrame(rafId);
+      }
+    }
+  };
 };


### PR DESCRIPTION
This change tries to improve the performances in two ways:

* Read the rect *after* the rAF is executed, because the browser usually makes a reflow after the rAF, so the getBoundingClientRect call won't trigger an extra reflow.  This is the solution explained [here](https://developer.mozilla.org/en-US/Firefox/Performance_best_practices_for_Firefox_fe_engineers#How_do_I_avoid_triggering_uninterruptible_reflow).

* Run everything in a single rAF, because poping a lot of rAF and setTimeouts is CPU intensive.

Example to benchmark the improvement:

[With the original code](https://rawgit.com/BenoitZugmeyer/e828421b941bbd363461b9959fe46f07/raw/b15e593dc93b4dd8cace4118cb5455aedd8f5d84/original.html), the browser makes a reflow every time the `getBoundingClientRect` is called. The example layout is really minimal, so it is really quick, but it could be a lot more complex.

A typical frame looks like this: 
![screenshot_20180602_215401](https://user-images.githubusercontent.com/61787/40880374-e3b71356-66af-11e8-85c5-d37c0f2aaa56.png)

[With the improved code](https://rawgit.com/BenoitZugmeyer/e828421b941bbd363461b9959fe46f07/raw/b15e593dc93b4dd8cace4118cb5455aedd8f5d84/improved.html), first we call `getBoundingClientRect` after the `rAF` occurs, so it doesn't trigger a reflow. But we also execute everything in a single `rAF` loop so it is less CPU intensive.

A typical frame looks like this:
![screenshot_20180602_215444](https://user-images.githubusercontent.com/61787/40880394-2c075594-66b0-11e8-953d-ad91c5033672.png)

The red dot is not centered anymore because blue dot positions are updated asynchronously, but we get to 60fps very easily.