### PR TITLE
Improve responsiveness

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,19 @@ let observedNodes = new Map();
 let rafId;
 
 let run = () => {
-  observedNodes.forEach(state => {
-    if (state.hasRectChanged) {
-      state.callbacks.forEach(cb => cb(state.rect));
-      state.hasRectChanged = false;
+  const changedStates = []
+
+  observedNodes.forEach((state, node) => {
+    let newRect = node.getBoundingClientRect();
+    if (rectChanged(newRect, state.rect)) {
+      state.rect = newRect;
+      changedStates.push(state);
     }
   });
 
-  setTimeout(() => {
-    observedNodes.forEach((state, node) => {
-      let newRect = node.getBoundingClientRect();
-      if (rectChanged(newRect, state.rect)) {
-        state.hasRectChanged = true;
-        state.rect = newRect;
-      }
-    });
-  }, 0);
+  changedStates.forEach(state => {
+    state.callbacks.forEach(cb => cb(state.rect));
+  });
 
   rafId = requestAnimationFrame(run);
 };
@@ -35,7 +32,6 @@ export default (node, cb) => {
       } else {
         observedNodes.set(node, {
           rect: undefined,
-          hasRectChanged: false,
           callbacks: [cb]
         });
       }


### PR DESCRIPTION
Ok so this PR is an iteration over my previous one (#1).

This removes the deferred computation of `rect`, so we can invoke callbacks as soon as possible, in the current frame.  We still group `getBoundingClientRect` calls and callbacks invocations, so we minimize
browser reflows.

I'll try to explain the logic a bit further: when modifying (writing) the DOM by creating nodes, editing style, ... the browser does not recompute everything (sizes, positions, colors...) right away, because it would cause really bad performances. Instead, it waits that all writings are done, and update everything at the end of the frame. But if some DOM values are read ([see comprehensive list of values here](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)) in the meantime, it has to recompute (reflow) right away, in a blocking manner. This is why we should always try to avoid interleaving DOM reads and writes in a frame.

The `observeRect` callbacks are likely to modify the DOM according to the new `rect` values. So if there is many callbacks to invoke, calling `getBoundingClientRect` between invocations will cause the browser to reflow everytime, which can be a performance bottleneck.

I hope it makes sense.