### PR TITLE
fix "repository" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.m.js",
   "source": "src/index.js",
-  "repository": "https://github.com/reach/rect-observer",
+  "repository": "https://github.com/reach/observe-rect",
   "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "dependencies": {},


### PR DESCRIPTION
"repository" field is wrong, leading to a 404 when trying to find the source code from the npm 'homepage' link