### PR TITLE
feat: Ship some type definitions too

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "files": [
     "src",
     "dist",
-    "README.md"
+    "README.md",
+    "types.d.ts"
   ],
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.m.js",
   "source": "src/index.js",
+  "types": "types.d.ts",
   "repository": "https://github.com/reach/rect-observer",
   "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,16 @@
+export interface RectObject {
+    width: number,
+    height: number,
+    top: number,
+    right: number,
+    bottom: number,
+    left: number
+}
+
+export interface ObservedObject {
+    observe(): void;
+
+    unobserve(): void;
+}
+
+export default function observeRect<T extends HTMLElement>(node: T, callback: (rect: RectObject) => void): ObservedObject;


### PR DESCRIPTION
With this PR I aim to include some type definitions for us TypeScript consumers of this library.

If you don't wish to maintain this in your library, would you endorse a PR into DefinitlyTyped?
