### PR TITLE
Cleaner implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,37 +31,37 @@ function assertDidUpdate(state: RectProps, node: Element){
 export default function observeRect(
 	node: Element,
 	callback: (rect: DOMRect) => void
-) {
+){
+	let state = observedNodes.get(node);
+
 	return {
-		observe() {
-			let wasEmpty = observedNodes.size === 0;
-			if (observedNodes.has(node)) {
-				observedNodes.get(node)!.callbacks.add(callback);
-			} else {
-				observedNodes.set(node, {
+		observe(){
+			if(state)
+				state.callbacks.add(callback);
+			else {
+				observedNodes.set(node, state = {
 					rect: {} as any,
 					callbacks: new Set([callback]),
 				});
-			}
-			if (wasEmpty) {
-				active = true;
-				checkForUpdates();
+		
+				if(!active){
+					active = true;
+					checkForUpdates();
+				}
 			}
 		},
-
-		unobserve() {
-			let state = observedNodes.get(node);
-			if (state) {
+		unobserve(){
+			if(state){
 				state.callbacks.delete(callback);
-
-				// Remove the node reference
-				if (!state.callbacks.size)
+	
+				if(!state.callbacks.size)
 					observedNodes.delete(node);
-
-				// Stop the loop
-				if (!observedNodes.size)
+	
+				state = undefined;
+	
+				if(!observedNodes.size)
 					active = false;
 			}
-		},
-	};
+		}
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 type RectProps = {
 	rect: DOMRect;
-	callbacks: Function[];
+	callbacks: Set<Function>;
 };
 
 let COMPARE_KEYS = [
@@ -30,17 +30,17 @@ function assertDidUpdate(state: RectProps, node: Element){
 
 export default function observeRect(
 	node: Element,
-	cb: (rect: DOMRect) => void
+	callback: (rect: DOMRect) => void
 ) {
 	return {
 		observe() {
 			let wasEmpty = observedNodes.size === 0;
 			if (observedNodes.has(node)) {
-				observedNodes.get(node)!.callbacks.push(cb);
+				observedNodes.get(node)!.callbacks.add(callback);
 			} else {
 				observedNodes.set(node, {
 					rect: {} as any,
-					callbacks: [cb],
+					callbacks: new Set([callback]),
 				});
 			}
 			if (wasEmpty) {
@@ -52,12 +52,11 @@ export default function observeRect(
 		unobserve() {
 			let state = observedNodes.get(node);
 			if (state) {
-				// Remove the callback
-				const index = state.callbacks.indexOf(cb);
-				if (index >= 0) state.callbacks.splice(index, 1);
+				state.callbacks.delete(callback);
 
 				// Remove the node reference
-				if (!state.callbacks.length) observedNodes.delete(node);
+				if (!state.callbacks.size)
+					observedNodes.delete(node);
 
 				// Stop the loop
 				if (!observedNodes.size)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,20 @@
-let props: (keyof DOMRect)[] = [
-	"bottom",
-	"height",
-	"left",
-	"right",
-	"top",
-	"width",
-];
-
-let rectChanged = (a: DOMRect = {} as DOMRect, b: DOMRect = {} as DOMRect) =>
-	props.some((prop) => a[prop] !== b[prop]);
+let COMPARE_KEYS = [
+	"bottom", "height", "left", "right", "top", "width"
+] as const;
 
 let observedNodes = new Map<Element, RectProps>();
 let rafId: number;
 
 let run = () => {
-	const changedStates: RectProps[] = [];
 	observedNodes.forEach((state, node) => {
 		let newRect = node.getBoundingClientRect();
-		if (rectChanged(newRect, state.rect)) {
-			state.rect = newRect;
-			changedStates.push(state);
-		}
-	});
 
-	changedStates.forEach((state) => {
-		state.callbacks.forEach((cb) => cb(state.rect));
+		for(const key of COMPARE_KEYS)
+			if(newRect[key] !== (state.rect || {})[key]){
+				state.rect = newRect;
+				state.callbacks.forEach(cb => cb(state.rect))
+				break;
+			}
 	});
 
 	rafId = window.requestAnimationFrame(run);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,67 +1,67 @@
 type RectProps = {
-	rect: DOMRect;
-	callbacks: Set<Function>;
+  rect: DOMRect;
+  callbacks: Set<Function>;
 };
 
 let COMPARE_KEYS = [
-	"bottom", "height", "left", "right", "top", "width"
+  "bottom", "height", "left", "right", "top", "width"
 ] as const;
 
 let observedNodes = new Map<Element, RectProps>();
 let active: boolean;
 
 function checkForUpdates(){
-	if(active){
-		observedNodes.forEach(assertDidUpdate);
-		window.requestAnimationFrame(checkForUpdates);
-	}
+  if(active){
+    observedNodes.forEach(assertDidUpdate);
+    window.requestAnimationFrame(checkForUpdates);
+  }
 };
 
 function assertDidUpdate(state: RectProps, node: Element){
-	let newRect = node.getBoundingClientRect();
+  let newRect = node.getBoundingClientRect();
 
-	for(const key of COMPARE_KEYS)
-		if(newRect[key] !== state.rect[key]){
-			state.rect = newRect;
-			state.callbacks.forEach(cb => cb(state.rect))
-			break;
-		}
+  for(const key of COMPARE_KEYS)
+    if(newRect[key] !== state.rect[key]){
+      state.rect = newRect;
+      state.callbacks.forEach(cb => cb(state.rect))
+      break;
+    }
 }
 
 export default function observeRect(
-	node: Element,
-	callback: (rect: DOMRect) => void
+  node: Element,
+  callback: (rect: DOMRect) => void
 ){
-	let state = observedNodes.get(node);
+  let state = observedNodes.get(node);
 
-	return {
-		observe(){
-			if(state)
-				state.callbacks.add(callback);
-			else {
-				observedNodes.set(node, state = {
-					rect: {} as any,
-					callbacks: new Set([callback]),
-				});
-		
-				if(!active){
-					active = true;
-					checkForUpdates();
-				}
-			}
-		},
-		unobserve(){
-			if(state){
-				state.callbacks.delete(callback);
-	
-				if(!state.callbacks.size)
-					observedNodes.delete(node);
-	
-				state = undefined;
-	
-				if(!observedNodes.size)
-					active = false;
-			}
-		}
-	}
+  return {
+    observe(){
+      if(state)
+        state.callbacks.add(callback);
+      else {
+        observedNodes.set(node, state = {
+          rect: {} as any,
+          callbacks: new Set([callback]),
+        });
+
+        if(!active){
+          active = true;
+          checkForUpdates();
+        }
+      }
+    },
+    unobserve(){
+      if(state){
+        state.callbacks.delete(callback);
+
+        if(!state.callbacks.size)
+          observedNodes.delete(node);
+
+        state = undefined;
+
+        if(!observedNodes.size)
+          active = false;
+      }
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+type RectProps = {
+	rect: DOMRect;
+	callbacks: Function[];
+};
+
 let COMPARE_KEYS = [
 	"bottom", "height", "left", "right", "top", "width"
 ] as const;
@@ -10,7 +15,7 @@ let run = () => {
 		let newRect = node.getBoundingClientRect();
 
 		for(const key of COMPARE_KEYS)
-			if(newRect[key] !== (state.rect || {})[key]){
+			if(newRect[key] !== state.rect[key]){
 				state.rect = newRect;
 				state.callbacks.forEach(cb => cb(state.rect))
 				break;
@@ -31,8 +36,7 @@ export default function observeRect(
 				observedNodes.get(node)!.callbacks.push(cb);
 			} else {
 				observedNodes.set(node, {
-					rect: undefined,
-					hasRectChanged: false,
+					rect: {} as any,
 					callbacks: [cb],
 				});
 			}
@@ -55,11 +59,3 @@ export default function observeRect(
 		},
 	};
 }
-
-export type PartialRect = Partial<DOMRect>;
-
-export type RectProps = {
-	rect: DOMRect | undefined;
-	hasRectChanged: boolean;
-	callbacks: Function[];
-};


### PR DESCRIPTION
Wanted to contribute a refactor I authored while reverse-engineering this module. I'm tinkering with [`react-virtual`](https://github.com/tannerlinsley/react-virtual) and found this to be it's only major dependency. Wanted to in-house logic on my end so iterating off this fork; at some point found a quick PR to be in order.

I've cleaned up the code to be more ES6'y and made it more readable. I've also pared down some unneeded steps and assertions. The algorithm should be a more efficient as a result, which is useful since it will run 60-120ips or more (especially on mobile).

To help with code-review:
- Split discrete improvements made into separate commits
- Changes are non-breaking and API exactly the same.
- Tested using included `serve` script and works fine.

Feedback welcome!
Cheers